### PR TITLE
Rename pack() into release()

### DIFF
--- a/libfastsignals/include/function.h
+++ b/libfastsignals/include/function.h
@@ -25,7 +25,7 @@ public:
 	function& operator=(const function& other) = default;
 	function& operator=(function&& other) noexcept = default;
 
-	template <class Fn, typename = enable_if_callable_t<Fn, function<Return(Arguments...)>, Return, Arguments...>> 
+	template <class Fn, typename = enable_if_callable_t<Fn, function<Return(Arguments...)>, Return, Arguments...>>
 	function(Fn&& function)
 	{
 		m_packed.init<Fn, Return, Arguments...>(std::forward<Fn>(function));
@@ -37,7 +37,7 @@ public:
 		return proxy(std::forward<Arguments>(args)...);
 	}
 
-	detail::packed_function pack()
+	detail::packed_function release()
 	{
 		return std::move(m_packed);
 	}

--- a/libfastsignals/include/signal.h
+++ b/libfastsignals/include/signal.h
@@ -16,7 +16,9 @@ namespace is::signals
 template <class Signature, template <class T> class Combiner = optional_last_value>
 class signal;
 
-struct advanced_tag {};
+struct advanced_tag
+{
+};
 
 // Signal allows to fire events to many subscribers (slots).
 // In other words, it implements one-to-many relation between event and listeners.
@@ -42,7 +44,7 @@ public:
 	 */
 	connection connect(slot_type slot)
 	{
-		const uint64_t id = m_slots->add(slot.pack());
+		const uint64_t id = m_slots->add(slot.release());
 		return connection(m_slots, id);
 	}
 

--- a/tests/libfastsignals_unit_tests/Function_tests.cpp
+++ b/tests/libfastsignals_unit_tests/Function_tests.cpp
@@ -233,3 +233,35 @@ TEST_CASE("Can move function", "[function]")
 	callback2();
 	REQUIRE(called);
 }
+
+TEST_CASE("Can release packed function", "[function]")
+{
+	function<int()> iota = [v = 0]() mutable {
+		return v++;
+	};
+	REQUIRE(iota() == 0);
+
+	auto packedFn = std::move(iota).release();
+	REQUIRE_THROWS_AS(iota(), std::bad_function_call);
+
+	auto&& proxy = packedFn.get<int()>();
+	REQUIRE(proxy() == 1);
+	REQUIRE(proxy() == 2);
+}
+
+TEST_CASE("Function copy has its own packed function", "[function]")
+{
+	function<int()> iota = [v = 0]() mutable {
+		return v++;
+	};
+
+	REQUIRE(iota() == 0);
+
+	auto iotaCopy(iota);
+
+	REQUIRE(iota() == 1);
+	REQUIRE(iota() == 2);
+
+	REQUIRE(iotaCopy() == 1);
+	REQUIRE(iotaCopy() == 2);
+}


### PR DESCRIPTION
It is not quite obvious that `function::pack()` call makes function object empty. I suggest renaming it into release()