### PR TITLE
Adds noexcept to connection and scoped_connection

### DIFF
--- a/libfastsignals/include/connection.h
+++ b/libfastsignals/include/connection.h
@@ -13,15 +13,15 @@ namespace is::signals
 class connection
 {
 public:
-	connection();
-	explicit connection(detail::signal_impl_weak_ptr storage, uint64_t id);
-	connection(const connection& other);
-	connection& operator=(const connection& other);
+	connection() noexcept;
+	explicit connection(detail::signal_impl_weak_ptr storage, uint64_t id) noexcept;
+	connection(const connection& other) noexcept;
+	connection& operator=(const connection& other) noexcept;
 	connection(connection&& other) noexcept;
 	connection& operator=(connection&& other) noexcept;
 
 	bool connected() const noexcept;
-	void disconnect();
+	void disconnect() noexcept;
 
 protected:
 	detail::signal_impl_weak_ptr m_storage;
@@ -43,10 +43,10 @@ public:
 	};
 	using impl_ptr = std::shared_ptr<advanced_connection_impl>;
 
-	advanced_connection();
+	advanced_connection() noexcept;
 	explicit advanced_connection(connection&& conn, impl_ptr&& impl) noexcept;
-	advanced_connection(const advanced_connection&);
-	advanced_connection& operator=(const advanced_connection&);
+	advanced_connection(const advanced_connection&) noexcept;
+	advanced_connection& operator=(const advanced_connection&) noexcept;
 	advanced_connection(advanced_connection&& other) noexcept;
 	advanced_connection& operator=(advanced_connection&& other) noexcept;
 
@@ -80,8 +80,8 @@ private:
 class scoped_connection : public connection
 {
 public:
-	scoped_connection();
-	scoped_connection(const connection& conn);
+	scoped_connection() noexcept;
+	scoped_connection(const connection& conn) noexcept;
 	scoped_connection(connection&& conn) noexcept;
 	scoped_connection(const advanced_connection& conn) = delete;
 	scoped_connection(advanced_connection&& conn) noexcept = delete;
@@ -91,15 +91,15 @@ public:
 	scoped_connection& operator=(scoped_connection&& other) noexcept;
 	~scoped_connection();
 
-	connection release();
+	connection release() noexcept;
 };
 
 // scoped connection for advanced connections
 class advanced_scoped_connection : public advanced_connection
 {
 public:
-	advanced_scoped_connection();
-	advanced_scoped_connection(const advanced_connection& conn);
+	advanced_scoped_connection() noexcept;
+	advanced_scoped_connection(const advanced_connection& conn) noexcept;
 	advanced_scoped_connection(advanced_connection&& conn) noexcept;
 	advanced_scoped_connection(const advanced_scoped_connection&) = delete;
 	advanced_scoped_connection& operator=(const advanced_scoped_connection&) = delete;
@@ -107,7 +107,7 @@ public:
 	advanced_scoped_connection& operator=(advanced_scoped_connection&& other) noexcept;
 	~advanced_scoped_connection();
 
-	advanced_connection release();
+	advanced_connection release() noexcept;
 };
 
 } // namespace is::signals

--- a/libfastsignals/include/connection.h
+++ b/libfastsignals/include/connection.h
@@ -58,10 +58,10 @@ protected:
 class shared_connection_block
 {
 public:
-	shared_connection_block(const advanced_connection& connection = advanced_connection(), bool initially_blocked = true);
-	shared_connection_block(const shared_connection_block& other);
+	shared_connection_block(const advanced_connection& connection = advanced_connection(), bool initially_blocked = true) noexcept;
+	shared_connection_block(const shared_connection_block& other) noexcept;
 	shared_connection_block(shared_connection_block&& other) noexcept;
-	shared_connection_block& operator=(const shared_connection_block& other);
+	shared_connection_block& operator=(const shared_connection_block& other) noexcept;
 	shared_connection_block& operator=(shared_connection_block&& other) noexcept;
 
 	void block() noexcept;

--- a/libfastsignals/src/connection.cpp
+++ b/libfastsignals/src/connection.cpp
@@ -4,13 +4,12 @@ namespace is::signals
 {
 namespace
 {
-inline void null_deleter(const void*) {}
 
 auto get_advanced_connection_impl(const advanced_connection& connection) noexcept
 {
-	struct advanced_connection_impl_getter : public advanced_connection
+	struct advanced_connection_impl_getter : private advanced_connection
 	{
-		advanced_connection_impl_getter(const advanced_connection& connection)
+		advanced_connection_impl_getter(const advanced_connection& connection) noexcept
 			: advanced_connection(connection)
 		{
 		}
@@ -18,6 +17,7 @@ auto get_advanced_connection_impl(const advanced_connection& connection) noexcep
 	};
 	return advanced_connection_impl_getter(connection).m_impl;
 }
+
 } // namespace
 
 connection::connection(connection&& other) noexcept

--- a/libfastsignals/src/connection.cpp
+++ b/libfastsignals/src/connection.cpp
@@ -12,12 +12,13 @@ auto get_advanced_connection_impl(const advanced_connection& connection)
 	{
 		advanced_connection_impl_getter(const advanced_connection& connection)
 			: advanced_connection(connection)
-		{}
+		{
+		}
 		using advanced_connection::m_impl;
 	};
 	return advanced_connection_impl_getter(connection).m_impl;
 }
-}
+} // namespace
 
 connection::connection(connection&& other) noexcept
 	: m_storage(other.m_storage)
@@ -27,15 +28,15 @@ connection::connection(connection&& other) noexcept
 	other.m_id = 0;
 }
 
-connection::connection(detail::signal_impl_weak_ptr storage, uint64_t id)
+connection::connection(detail::signal_impl_weak_ptr storage, uint64_t id) noexcept
 	: m_storage(std::move(storage))
 	, m_id(id)
 {
 }
 
-connection::connection() = default;
+connection::connection() noexcept = default;
 
-connection::connection(const connection& other) = default;
+connection::connection(const connection& other) noexcept = default;
 
 connection& connection::operator=(connection&& other) noexcept
 {
@@ -46,14 +47,14 @@ connection& connection::operator=(connection&& other) noexcept
 	return *this;
 }
 
-connection& connection::operator=(const connection& other) = default;
+connection& connection::operator=(const connection& other) noexcept = default;
 
 bool connection::connected() const noexcept
 {
 	return (m_id != 0);
 }
 
-void connection::disconnect()
+void connection::disconnect() noexcept
 {
 	if (auto storage = m_storage.lock())
 	{
@@ -68,12 +69,12 @@ scoped_connection::scoped_connection(connection&& conn) noexcept
 {
 }
 
-scoped_connection::scoped_connection(const connection& conn)
+scoped_connection::scoped_connection(const connection& conn) noexcept
 	: connection(conn)
 {
 }
 
-scoped_connection::scoped_connection() = default;
+scoped_connection::scoped_connection() noexcept = default;
 
 scoped_connection::scoped_connection(scoped_connection&& other) noexcept = default;
 
@@ -89,7 +90,7 @@ scoped_connection::~scoped_connection()
 	disconnect();
 }
 
-connection scoped_connection::release()
+connection scoped_connection::release() noexcept
 {
 	connection conn = std::move(static_cast<connection&>(*this));
 	return conn;
@@ -110,7 +111,7 @@ void advanced_connection::advanced_connection_impl::unblock() noexcept
 	--m_blockCounter;
 }
 
-advanced_connection::advanced_connection() = default;
+advanced_connection::advanced_connection() noexcept = default;
 
 advanced_connection::advanced_connection(connection&& conn, impl_ptr&& impl) noexcept
 	: connection(std::move(conn))
@@ -118,11 +119,11 @@ advanced_connection::advanced_connection(connection&& conn, impl_ptr&& impl) noe
 {
 }
 
-advanced_connection::advanced_connection(const advanced_connection&) = default;
+advanced_connection::advanced_connection(const advanced_connection&) noexcept = default;
 
 advanced_connection::advanced_connection(advanced_connection&& other) noexcept = default;
 
-advanced_connection& advanced_connection::operator=(const advanced_connection&) = default;
+advanced_connection& advanced_connection::operator=(const advanced_connection&) noexcept = default;
 
 advanced_connection& advanced_connection::operator=(advanced_connection&& other) noexcept = default;
 
@@ -215,9 +216,9 @@ void shared_connection_block::increment_if_blocked() const noexcept
 	}
 }
 
-advanced_scoped_connection::advanced_scoped_connection() = default;
+advanced_scoped_connection::advanced_scoped_connection() noexcept = default;
 
-advanced_scoped_connection::advanced_scoped_connection(const advanced_connection& conn)
+advanced_scoped_connection::advanced_scoped_connection(const advanced_connection& conn) noexcept
 	: advanced_connection(conn)
 {
 }
@@ -236,7 +237,7 @@ advanced_scoped_connection::~advanced_scoped_connection()
 	disconnect();
 }
 
-advanced_connection advanced_scoped_connection::release()
+advanced_connection advanced_scoped_connection::release() noexcept
 {
 	advanced_connection conn = std::move(static_cast<advanced_connection&>(*this));
 	return conn;

--- a/libfastsignals/src/connection.cpp
+++ b/libfastsignals/src/connection.cpp
@@ -6,7 +6,7 @@ namespace
 {
 inline void null_deleter(const void*) {}
 
-auto get_advanced_connection_impl(const advanced_connection& connection)
+auto get_advanced_connection_impl(const advanced_connection& connection) noexcept
 {
 	struct advanced_connection_impl_getter : public advanced_connection
 	{
@@ -127,7 +127,7 @@ advanced_connection& advanced_connection::operator=(const advanced_connection&) 
 
 advanced_connection& advanced_connection::operator=(advanced_connection&& other) noexcept = default;
 
-shared_connection_block::shared_connection_block(const advanced_connection& connection, bool initially_blocked)
+shared_connection_block::shared_connection_block(const advanced_connection& connection, bool initially_blocked) noexcept
 	: m_connection(get_advanced_connection_impl(connection))
 {
 	if (initially_blocked)
@@ -136,7 +136,7 @@ shared_connection_block::shared_connection_block(const advanced_connection& conn
 	}
 }
 
-shared_connection_block::shared_connection_block(const shared_connection_block& other)
+shared_connection_block::shared_connection_block(const shared_connection_block& other) noexcept
 	: m_connection(other.m_connection)
 	, m_blocked(other.m_blocked.load(std::memory_order_acquire))
 {
@@ -151,7 +151,7 @@ shared_connection_block::shared_connection_block(shared_connection_block&& other
 	other.m_blocked.store(false, std::memory_order_release);
 }
 
-shared_connection_block& shared_connection_block::operator=(const shared_connection_block& other)
+shared_connection_block& shared_connection_block::operator=(const shared_connection_block& other) noexcept
 {
 	if (&other != this)
 	{


### PR DESCRIPTION
The following methods were declared noexcept:
- constructors and copy assignment operators of connection class
- default constructor of scoped_connection
- scoped_connection(const connection&)