### PR TITLE
spin_mutex is moved to detail and is declared noexcept

### DIFF
--- a/libfastsignals/include/spin_mutex.h
+++ b/libfastsignals/include/spin_mutex.h
@@ -13,12 +13,12 @@ public:
 	spin_mutex(spin_mutex&&) = delete;
 	spin_mutex& operator=(spin_mutex&&) = delete;
 
-	inline bool try_lock()
+	inline bool try_lock() noexcept
 	{
 		return !m_busy.test_and_set(std::memory_order_acquire);
 	}
 
-	inline void lock()
+	inline void lock() noexcept
 	{
 		while (!try_lock())
 		{
@@ -26,7 +26,7 @@ public:
 		}
 	}
 
-	inline void unlock()
+	inline void unlock() noexcept
 	{
 		m_busy.clear(std::memory_order_release);
 	}

--- a/libfastsignals/include/spin_mutex.h
+++ b/libfastsignals/include/spin_mutex.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <atomic>
 
-namespace is::signals
+namespace is::signals::detail
 {
 
 class spin_mutex
@@ -35,4 +35,4 @@ private:
 	std::atomic_flag m_busy = ATOMIC_FLAG_INIT;
 };
 
-} // namespace is::signals
+} // namespace is::signals::detail


### PR DESCRIPTION
spin_mutex class is an implementation detail and should not be exposed to library users

Also we must declare methods are declared noexcept. Otherwise signal_impl::remove() and signal_impl::remove_all() methods can't be declared noexcept if spin_mutex::lock is allowed to throw