### PR TITLE
Makes signal_impl::count() threadsafe

### DIFF
--- a/libfastsignals/include/spin_mutex.h
+++ b/libfastsignals/include/spin_mutex.h
@@ -13,12 +13,12 @@ public:
 	spin_mutex(spin_mutex&&) = delete;
 	spin_mutex& operator=(spin_mutex&&) = delete;
 
-	inline bool try_lock()
+	inline bool try_lock() noexcept
 	{
 		return !m_busy.test_and_set(std::memory_order_acquire);
 	}
 
-	inline void lock()
+	inline void lock() noexcept
 	{
 		while (!try_lock())
 		{
@@ -26,7 +26,7 @@ public:
 		}
 	}
 
-	inline void unlock()
+	inline void unlock() noexcept
 	{
 		m_busy.clear(std::memory_order_release);
 	}

--- a/libfastsignals/include/spin_mutex.h
+++ b/libfastsignals/include/spin_mutex.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <atomic>
 
-namespace is::signals
+namespace is::signals::detail
 {
 
 class spin_mutex
@@ -35,4 +35,4 @@ private:
 	std::atomic_flag m_busy = ATOMIC_FLAG_INIT;
 };
 
-} // namespace is::signals
+} // namespace is::signals::detail

--- a/libfastsignals/src/signal_impl.cpp
+++ b/libfastsignals/src/signal_impl.cpp
@@ -62,6 +62,8 @@ bool signal_impl::get_next_slot(packed_function& slot, size_t& expectedIndex, ui
 
 size_t signal_impl::count() const noexcept
 {
+	std::lock_guard lock(m_mutex);
+
 	return m_functions.size();
 }
 


### PR DESCRIPTION
signal_impl::count() invokes `m_function.size()` without locking a mutex. This PR fixes this issue.
This PR depends on #16 (make spin_mutex methods noexcept).