### PR TITLE
Makes function::release() noexcept

### DIFF
--- a/libfastsignals/include/function.h
+++ b/libfastsignals/include/function.h
@@ -42,7 +42,7 @@ public:
 		return proxy(std::forward<Arguments>(args)...);
 	}
 
-	detail::packed_function release()
+	detail::packed_function release() noexcept
 	{
 		return std::move(m_packed);
 	}


### PR DESCRIPTION
packed_function move constructor is noexcept, so we can make function::release() noexcept too