### PR TITLE
Declares function constructor noexcept when possible

### DIFF
--- a/libfastsignals/include/function.h
+++ b/libfastsignals/include/function.h
@@ -31,7 +31,7 @@ public:
 	function& operator=(function&& other) noexcept = default;
 
 	template <class Fn, typename = enable_if_callable_t<Fn, function<Return(Arguments...)>, Return, Arguments...>>
-	function(Fn&& function) noexcept(noexcept(detail::packed_function().init<Fn, Return, Arguments...>(std::forward<Fn>(function))))
+	function(Fn&& function) noexcept(detail::is_noexcept_packed_function_init<Fn, Return, Arguments...>)
 	{
 		m_packed.init<Fn, Return, Arguments...>(std::forward<Fn>(function));
 	}

--- a/libfastsignals/include/function.h
+++ b/libfastsignals/include/function.h
@@ -31,7 +31,7 @@ public:
 	function& operator=(function&& other) noexcept = default;
 
 	template <class Fn, typename = enable_if_callable_t<Fn, function<Return(Arguments...)>, Return, Arguments...>>
-	function(Fn&& function)
+	function(Fn&& function) noexcept(noexcept(detail::packed_function().init<Fn, Return, Arguments...>(std::forward<Fn>(function))))
 	{
 		m_packed.init<Fn, Return, Arguments...>(std::forward<Fn>(function));
 	}

--- a/libfastsignals/include/function_detail.h
+++ b/libfastsignals/include/function_detail.h
@@ -107,6 +107,9 @@ private:
 	callable_copy_t<Callable> m_callable;
 };
 
+template <class Fn, class Return, class... Arguments>
+inline constexpr bool is_noexcept_packed_function_init = can_use_inplace_buffer<function_proxy_impl<Fn, Return, Arguments...>>;
+
 class packed_function
 {
 public:
@@ -120,7 +123,7 @@ public:
 	// Initializes packed function.
 	// Cannot be called without reset().
 	template <class Callable, class Return, class... Arguments>
-	void init(Callable&& function) noexcept(can_use_inplace_buffer<function_proxy_impl<Callable, Return, Arguments...>>)
+	void init(Callable&& function) noexcept(is_noexcept_packed_function_init<Callable, Return, Arguments...>)
 	{
 		using proxy_t = function_proxy_impl<Callable, Return, Arguments...>;
 


### PR DESCRIPTION
If packed function can be initialized without exceptions with given callable object, then template function constructor can be also declared noexcept