### PR TITLE
Allows function to copy non-movable callable

### DIFF
--- a/libfastsignals/include/function_detail.h
+++ b/libfastsignals/include/function_detail.h
@@ -66,9 +66,15 @@ public:
 	static_assert(std::is_same_v<std::invoke_result_t<Callable, Arguments...>, Return>,
 		"cannot construct function<> class from callable object with different return type");
 
-	template <class FunctionObject>
+	template <class FunctionObject, typename = std::enable_if_t<std::is_move_constructible_v<FunctionObject>>>
 	explicit function_proxy_impl(FunctionObject&& function)
 		: m_callable(std::forward<FunctionObject>(function))
+	{
+	}
+
+	template <class FunctionObject, typename = std::enable_if_t<std::is_copy_constructible_v<FunctionObject>>>
+	explicit function_proxy_impl(const FunctionObject& function)
+		: m_callable(function)
 	{
 	}
 

--- a/tests/libfastsignals_unit_tests/Function_tests.cpp
+++ b/tests/libfastsignals_unit_tests/Function_tests.cpp
@@ -403,6 +403,18 @@ TEST_CASE("uses move constructor if it is noexcept", "[function]")
 	CHECK_THROWS(f());
 }
 
+TEST_CASE("uses Callable's copy constructor if move constructor is not available", "[function]")
+{
+	struct Callable
+	{
+		Callable() = default;
+		Callable(Callable&&) = delete;
+		Callable(const Callable&) = default;
+		void operator()() const {}
+	};
+	function<void()> fn(Callable{});
+}
+
 TEST_CASE("can copy and move empty function", "[function]")
 {
 	function<void()> f;


### PR DESCRIPTION
This PR allows function construction from non movable (but copyable) types.