### PR TITLE
Function assignment exception safe

### DIFF
--- a/libfastsignals/include/function_detail.h
+++ b/libfastsignals/include/function_detail.h
@@ -112,7 +112,7 @@ private:
 template <class Fn, class Return, class... Arguments>
 inline constexpr bool is_noexcept_packed_function_init = can_use_inplace_buffer<function_proxy_impl<Fn, Return, Arguments...>>;
 
-class packed_function
+class packed_function final
 {
 public:
 	packed_function() = default;
@@ -149,7 +149,6 @@ public:
 	void reset() noexcept;
 
 private:
-	base_function_proxy* copy_proxy_from(const packed_function& other);
 	base_function_proxy* move_proxy_from(packed_function&& other) noexcept;
 	base_function_proxy& unwrap() const;
 	bool is_buffer_allocated() const noexcept;

--- a/libfastsignals/include/function_detail.h
+++ b/libfastsignals/include/function_detail.h
@@ -9,7 +9,7 @@ namespace is::signals::detail
 {
 /// Buffer for callable object in-place construction,
 /// helps to implement Small Buffer Optimization.
-static constexpr size_t inplace_buffer_size = (sizeof(int) == sizeof(void*) ? 6 : 4) * sizeof(void*);
+static constexpr size_t inplace_buffer_size = (sizeof(int) == sizeof(void*) ? 8 : 6) * sizeof(void*);
 
 /// Structure that has size enough to keep type "T" including vtable.
 template <class T>
@@ -28,7 +28,9 @@ inline constexpr bool fits_inplace_buffer = (sizeof(type_container<T>) <= inplac
 // clang-format off
 /// Constantly is true if callable fits function buffer and can be safely moved, false otherwise
 template <class T>
-inline constexpr bool can_use_inplace_buffer = fits_inplace_buffer<T> && std::is_nothrow_move_constructible_v<T>;
+inline constexpr bool can_use_inplace_buffer = 
+	fits_inplace_buffer<T> && 
+	std::is_nothrow_move_constructible_v<T>;
 // clang format on
 
 /// Type that is suitable to keep copy of callable object.
@@ -144,8 +146,11 @@ public:
 		return static_cast<function_proxy<Signature>&>(unwrap());
 	}
 
-private:
 	void reset() noexcept;
+
+private:
+	base_function_proxy* copy_proxy_from(const packed_function& other);
+	base_function_proxy* move_proxy_from(packed_function&& other) noexcept;
 	base_function_proxy& unwrap() const;
 	bool is_buffer_allocated() const noexcept;
 

--- a/libfastsignals/include/function_detail.h
+++ b/libfastsignals/include/function_detail.h
@@ -150,6 +150,7 @@ public:
 
 private:
 	base_function_proxy* move_proxy_from(packed_function&& other) noexcept;
+	base_function_proxy* clone_proxy_from(const packed_function &other);
 	base_function_proxy& unwrap() const;
 	bool is_buffer_allocated() const noexcept;
 

--- a/libfastsignals/src/function_detail.cpp
+++ b/libfastsignals/src/function_detail.cpp
@@ -11,7 +11,7 @@ packed_function::packed_function(packed_function&& other) noexcept
 }
 
 packed_function::packed_function(const packed_function& other)
-	: m_proxy(copy_proxy_from(other))
+	: m_proxy(other.m_proxy ? other.m_proxy->clone(&m_buffer) : nullptr)
 {
 }
 
@@ -21,11 +21,6 @@ packed_function& packed_function::operator=(packed_function&& other) noexcept
 	reset();
 	m_proxy = move_proxy_from(std::move(other));
 	return *this;
-}
-
-base_function_proxy* packed_function::copy_proxy_from(const packed_function& other)
-{
-	return other.m_proxy ? other.m_proxy->clone(&m_buffer) : nullptr;
 }
 
 base_function_proxy* packed_function::move_proxy_from(packed_function&& other) noexcept

--- a/libfastsignals/src/signal_impl.cpp
+++ b/libfastsignals/src/signal_impl.cpp
@@ -65,6 +65,7 @@ bool signal_impl::get_next_slot(packed_function& slot, size_t& expectedIndex, ui
 		expectedIndex = std::distance(m_ids.cbegin(), it);
 	}
 
+	slot.reset();
 	slot = m_functions[expectedIndex];
 	nextId = (expectedIndex + 1 < m_ids.size()) ? m_ids[expectedIndex + 1] : m_ids[expectedIndex] + 1;
 	++expectedIndex;

--- a/tests/libfastsignals_unit_tests/Function_tests.cpp
+++ b/tests/libfastsignals_unit_tests/Function_tests.cpp
@@ -459,3 +459,69 @@ TEST_CASE("properly copies callable on assignment", "[function]")
 	CHECK(aliveCounter1 == 0);
 	CHECK(aliveCounter2 == 0);
 }
+
+TEST_CASE("copy assignment operator provides strong exception safety", "[function]")
+{
+	struct State
+	{
+		int callCount = 0;
+		bool throwOnCopy = false;
+	};
+	struct Callable
+	{
+		Callable(State& state)
+			: state(&state)
+		{
+		}
+		void operator()()
+		{
+			++state->callCount;
+		}
+		Callable(const Callable& other)
+			: state(other.state)
+		{
+			if (state->throwOnCopy)
+			{
+				throw std::runtime_error("throw on request");
+			}
+		}
+		State* state = nullptr;
+	};
+	static_assert(!detail::can_use_inplace_buffer<Callable>);
+
+	State srcState;
+	State dstState;
+
+	function<void()> srcFn(Callable{ srcState });
+	function<void()> dstFn(Callable{ dstState });
+
+	srcFn();
+	dstFn();
+
+	REQUIRE(srcState.callCount == 1);
+	REQUIRE(dstState.callCount == 1);
+
+	srcState.throwOnCopy = true;
+
+	REQUIRE_THROWS_AS(dstFn = srcFn, std::runtime_error);
+
+	// srcFn and dstFn must not be emptied even if assignment throws
+	REQUIRE_NOTHROW(srcFn());
+	REQUIRE_NOTHROW(dstFn());
+
+	// srcFn and dstFn must keep their state
+	REQUIRE(srcState.callCount == 2);
+	REQUIRE(dstState.callCount == 2);
+
+	// The next copy will succeed
+	srcState.throwOnCopy = false;
+	REQUIRE_NOTHROW(dstFn = srcFn);
+
+	// Both functions are usable
+	REQUIRE_NOTHROW(srcFn());
+	REQUIRE_NOTHROW(dstFn());
+
+	// After assignment, dstFn and srcFn refer the same state - srcState
+	REQUIRE(srcState.callCount == 4);
+	REQUIRE(dstState.callCount == 2);
+}


### PR DESCRIPTION
This PR makes function copy assignment operator more exception safe.
To achieve this, we should use SBO only when Callable is nothrow_copy_constructible.
In this case it is safe to call `reset()` before `clone()` into buffer
When function proxy is stored on heap, we must clone it befor resetting the old Callable.