### PR TITLE
Speeds up signal emitting by avoiding binary search when possible

### DIFF
--- a/libfastsignals/src/signal_impl.cpp
+++ b/libfastsignals/src/signal_impl.cpp
@@ -67,6 +67,7 @@ bool signal_impl::get_next_slot(packed_function& slot, size_t& expectedIndex, ui
 
 	slot = m_functions[expectedIndex];
 	nextId = (expectedIndex + 1 < m_ids.size()) ? m_ids[expectedIndex + 1] : m_ids[expectedIndex] + 1;
+	++expectedIndex;
 	return true;
 }
 


### PR DESCRIPTION
Fixes broken optimization in get_next_slot()