### PR TITLE
shared_connection_block should unblock in its destructor

### DIFF
--- a/libfastsignals/include/connection.h
+++ b/libfastsignals/include/connection.h
@@ -63,6 +63,7 @@ public:
 	shared_connection_block(shared_connection_block&& other) noexcept;
 	shared_connection_block& operator=(const shared_connection_block& other) noexcept;
 	shared_connection_block& operator=(shared_connection_block&& other) noexcept;
+	~shared_connection_block();
 
 	void block() noexcept;
 	void unblock() noexcept;

--- a/libfastsignals/src/connection.cpp
+++ b/libfastsignals/src/connection.cpp
@@ -176,6 +176,11 @@ shared_connection_block& shared_connection_block::operator=(shared_connection_bl
 	return *this;
 }
 
+shared_connection_block::~shared_connection_block()
+{
+	unblock();
+}
+
 void shared_connection_block::block() noexcept
 {
 	bool blocked = false;


### PR DESCRIPTION
Boost:

> A shared_connection_block releases its block when it is destroyed or its unblock method is called.

The following simple test case fails:

```
callbackCalled = false;
event(value);
CHECK(callbackCalled);

{
    callbackCalled = false;
    shared_connection_block block(conn);
    event(value);
    CHECK(!callbackCalled);
}

callbackCalled = false;
event(value);
CHECK(callbackCalled); // <-- fails here because the connection is still blocked
```

shared_connection_block doesn't have a destructor to unblock its connection, and none of the existing test cases cover this simple scenario.

In this PR I simply add unblock() to the destructor.