### PR TITLE
call destructor on moved-from in-place proxy

### DIFF
--- a/libfastsignals/include/function_detail.h
+++ b/libfastsignals/include/function_detail.h
@@ -96,7 +96,9 @@ public:
 	{
 		if constexpr (can_use_inplace_buffer<function_proxy_impl>)
 		{
-			return new (buffer) function_proxy_impl(std::move(*this));
+			base_function_proxy* moved = new (buffer) function_proxy_impl(std::move(*this));
+			this->~function_proxy_impl();
+			return moved;
 		}
 		else
 		{

--- a/tests/libfastsignals_unit_tests/signal_tests.cpp
+++ b/tests/libfastsignals_unit_tests/signal_tests.cpp
@@ -674,3 +674,34 @@ TEST_CASE("Signal can be used as a slot for another signal", "[signal]")
 
 	CHECK(called);
 }
+
+// memory leak fix
+TEST_CASE("Releases lambda and its captured const data", "[signal]")
+{
+	struct Captured
+	{
+		Captured(bool& released)
+			: m_released(released)
+		{
+		}
+
+		~Captured()
+		{
+			m_released = true;
+		}
+
+	private:
+		bool& m_released;
+	};
+
+	bool released = false;
+
+	{
+		const auto captured = std::make_shared<Captured>(released);
+
+		signal<void()> changeSignal;
+		changeSignal.connect([captured]{});
+	}
+
+	CHECK(released);
+}


### PR DESCRIPTION
In `function_proxy_impl::move` with SBO enabled a proxy is moved-from but never destroyed. In some cases, it results in memory leaks.

The fix is to explicitly call its destructor.